### PR TITLE
Update omniauth dependencies to modern versions

### DIFF
--- a/omniauth-bike-index.gemspec
+++ b/omniauth-bike-index.gemspec
@@ -20,8 +20,8 @@ Gem::Specification.new do |spec|
   spec.files = `git ls-files`.split("\n")
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "omniauth", "~> 1.2"
-  spec.add_runtime_dependency "omniauth-oauth2", "~> 1.1"
+  spec.add_runtime_dependency "omniauth", "~> 2.0"
+  spec.add_runtime_dependency "omniauth-oauth2", "~> 1.8"
 
   spec.add_development_dependency "dotenv", "~> 0"
   spec.add_development_dependency "sinatra", "~> 0"


### PR DESCRIPTION
Update `omniauth` from `~> 1.2` to `~> 2.0` and `omniauth-oauth2` from `~> 1.1` to `~> 1.8`. The old pins prevented users from using OmniAuth 2.x, which has been out since 2021 and includes important CSRF fixes. The strategy code is fully compatible with the newer versions — all 26 tests pass with omniauth 2.1.4 and omniauth-oauth2 1.9.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)