### PR TITLE
Fix param_or_option precedence and preserve empty arrays in prune!

### DIFF
--- a/lib/omniauth/strategies/bike_index.rb
+++ b/lib/omniauth/strategies/bike_index.rb
@@ -35,8 +35,7 @@ module OmniAuth
         # omniauth.params are the parameters passed in to the URL
         # (e.g. company in /users/auth/bike_index?company=Metro)
         # So for partner, company and unauthenticated_redirect it tries those params, then goes from settings
-        session["omniauth.params"] && session["omniauth.params"][key] ||
-          options[key]
+        session.dig("omniauth.params", key) || options[key]
       end
 
       def request_phase
@@ -59,7 +58,7 @@ module OmniAuth
       def prune!(hash)
         hash.delete_if do |_, value|
           prune!(value) if value.is_a?(Hash)
-          value.nil? || (value.respond_to?(:empty?) && value.empty?)
+          value.nil? || (value.is_a?(Hash) && value.empty?) || (value.is_a?(String) && value.empty?)
         end
       end
     end

--- a/spec/omniauth/strategies/bike_index_spec.rb
+++ b/spec/omniauth/strategies/bike_index_spec.rb
@@ -110,7 +110,8 @@ describe OmniAuth::Strategies::BikeIndex do
         expect(subject.info).to eq(
           "nickname" => "bike_rider",
           "bike_ids" => [1],
-          "email" => "rider@example.com"
+          "email" => "rider@example.com",
+          "secondary_emails" => []
         )
       end
     end
@@ -236,9 +237,9 @@ describe OmniAuth::Strategies::BikeIndex do
       expect(result).to eq({"a" => 1})
     end
 
-    it "removes empty arrays" do
+    it "preserves empty arrays" do
       result = subject.send(:prune!, {"a" => 1, "b" => []})
-      expect(result).to eq({"a" => 1})
+      expect(result).to eq({"a" => 1, "b" => []})
     end
 
     it "removes empty nested hashes" do


### PR DESCRIPTION
- Replace fragile `&&`/`||` chain in `param_or_option` with `session.dig("omniauth.params", key) || options[key]` to eliminate operator precedence ambiguity.
- Change `prune!` to only remove nil values, empty hashes, and empty strings — empty arrays (e.g. `bike_ids: []`) are now preserved as a valid "no items" signal distinct from nil.
- Update tests to reflect the new behavior.